### PR TITLE
chore: update keywords in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   </a>
 </p>
 <h1 align="center">
-  Medusa
+  Medusa Plugin Starter
 </h1>
 
 <h4 align="center">
@@ -34,19 +34,21 @@
 
 ## Compatibility
 
-This starter is compatible with versions >= 2.0.0 of `@medusajs/medusa`. 
+This starter is compatible with versions >= 2.4.0 of `@medusajs/medusa`. 
 
 ## Getting Started
 
-Visit the [Quickstart Guide](https://docs.medusajs.com/learn) to set up a server.
+Visit the [Quickstart Guide](https://docs.medusajs.com/learn/installation) to set up a server.
 
-Visit the [Docs](https://docs.medusajs.com/learn#get-started) to learn more about our system requirements.
+Visit the [Plugins documentation](https://docs.medusajs.com/learn/fundamentals/plugins) to learn more about plugins and how to create them.
+
+Visit the [Docs](https://docs.medusajs.com/learn/installation#get-started) to learn more about our system requirements.
 
 ## What is Medusa
 
 Medusa is a set of commerce modules and tools that allow you to build rich, reliable, and performant commerce applications without reinventing core commerce logic. The modules can be customized and used to build advanced ecommerce stores, marketplaces, or any product that needs foundational commerce primitives. All modules are open-source and freely available on npm.
 
-Learn more about [Medusa’s architecture](https://docs.medusajs.com/learn/advanced-development/architecture/overview) and [commerce modules](https://docs.medusajs.com/learn/basics/commerce-modules) in the Docs.
+Learn more about [Medusa’s architecture](https://docs.medusajs.com/learn/introduction/architecture) and [commerce modules](https://docs.medusajs.com/learn/fundamentals/modules/commerce-modules) in the Docs.
 
 ## Community & Contributions
 

--- a/package.json
+++ b/package.json
@@ -8,13 +8,9 @@
     ".medusa/server"
   ],
   "keywords": [
-    "sqlite",
-    "postgres",
-    "typescript",
-    "ecommerce",
-    "headless",
     "medusa",
-    "plugin"
+    "plugin",
+    "medusa-plugin-other"
   ],
   "scripts": {
     "build": "medusa plugin:build",

--- a/src/links/README.md
+++ b/src/links/README.md
@@ -2,19 +2,25 @@
 
 A module link forms an association between two data models of different modules, while maintaining module isolation.
 
+Learn more about links in [this documentation](https://docs.medusajs.com/learn/fundamentals/module-links)
+
 For example:
 
 ```ts
-import HelloModule from "../modules/hello"
+import BlogModule from "../modules/blog"
 import ProductModule from "@medusajs/medusa/product"
 import { defineLink } from "@medusajs/framework/utils"
 
 export default defineLink(
   ProductModule.linkable.product,
-  HelloModule.linkable.myCustom
+  BlogModule.linkable.post
 )
 ```
 
-This defines a link between the Product Module's `product` data model and the Hello Module (custom module)'s `myCustom` data model.
+This defines a link between the Product Module's `product` data model and the Blog Module (custom module)'s `post` data model.
 
-Learn more about links in [this documentation](https://docs.medusajs.com/learn/fundamentals/module-links)
+Then, in the Medusa application using this plugin, run the following command to sync the links to the database:
+
+```bash
+npx medusa db:migrate
+```

--- a/src/modules/README.md
+++ b/src/modules/README.md
@@ -93,3 +93,24 @@ export async function GET(
 }
 ```
 
+## Module Options
+
+When you register the plugin in the Medusa application, it can accept options. These options are passed to the modules within the plugin:
+
+```ts
+import { defineConfig } from "@medusajs/framework/utils"
+
+module.exports = defineConfig({
+  // ...
+  plugins: [
+    {
+      resolve: "@myorg/plugin-name",
+      options: {
+        apiKey: process.env.API_KEY,
+      },
+    },
+  ],
+})
+```
+
+Learn more about module options in [this documentation](https://docs.medusajs.com/learn/fundamentals/modules/options).

--- a/src/modules/README.md
+++ b/src/modules/README.md
@@ -68,7 +68,7 @@ npx medusa plugin:db:genreate
 
 ## Use Module
 
-You can use the module in customizations within the plugin or within the Medusa application using this module. When the plugin is added to a Medusa application, all its modules are registered as well.
+You can use the module in customizations within the plugin or within the Medusa application using this plugin. When the plugin is added to a Medusa application, all its modules are registered as well.
 
 For example, to use the module in an API route:
 

--- a/src/modules/README.md
+++ b/src/modules/README.md
@@ -1,78 +1,95 @@
 # Custom Module
 
-A module is a package of reusable functionalities. It can be integrated into your Medusa application without affecting the overall system.
+A module is a package of reusable functionalities. It can be integrated into your Medusa application without affecting the overall system. You can create a module as part of a plugin.
+
+Learn more about modules in [this documentation](https://docs.medusajs.com/learn/fundamentals/modules).
 
 To create a module:
 
-## 1. Create a Service
+## 1. Create a Data Model
+
+A data model represents a table in the database. You create a data model in a TypeScript or JavaScript file under the `models` directory of a module.
+
+For example, create the file `src/modules/blog/models/post.ts` with the following content:
+
+```ts
+import { model } from "@medusajs/framework/utils"
+
+const Post = model.define("post", {
+  id: model.id().primaryKey(),
+  title: model.text(),
+})
+
+export default Post
+```
+
+## 2. Create a Service
 
 A module must define a service. A service is a TypeScript or JavaScript class holding methods related to a business logic or commerce functionality.
 
-For example, create the file `src/modules/hello/service.ts` with the following content:
+For example, create the file `src/modules/blog/service.ts` with the following content:
 
-```ts title="src/modules/hello/service.ts"
-export default class HelloModuleService {
-  getMessage() {
-    return "Hello, world!"
-  }
+```ts
+import { MedusaService } from "@medusajs/framework/utils"
+import Post from "./models/post"
+
+class BlogModuleService extends MedusaService({
+  Post,
+}){
 }
+
+export default BlogModuleService
 ```
 
-## 2. Export Module Definition
+## 3. Export Module Definition
 
 A module must have an `index.ts` file in its root directory that exports its definition. The definition specifies the main service of the module.
 
-For example, create the file `src/modules/hello/index.ts` with the following content:
+For example, create the file `src/modules/blog/index.ts` with the following content:
 
-```ts title="src/modules/hello.index.ts" highlights={[["4", "", "The main service of the module."]]}
-import HelloModuleService from "./service"
+```ts
+import BlogModuleService from "./service"
 import { Module } from "@medusajs/framework/utils"
 
-export const HELLO_MODULE = "hello"
+export const BLOG_MODULE = "blog"
 
-export default Module(HELLO_MODULE, {
-  service: HelloModuleService,
+export default Module(BLOG_MODULE, {
+  service: BlogModuleService,
 })
 ```
 
-## 3. Add Module to Configurations
+## 4. Generate Migrations
 
-The last step is to add the module in Medusa’s configurations.
+To generate migrations for your module, run the following command in the plugin's directory:
 
-In `medusa-config.js`, add the module to the `modules` object:
-
-```js title="medusa-config.js"
-import { HELLO_MODULE } from "./src/modules/hello"
-
-module.exports = defineConfig({
-  // ...
-  modules: [
-    {
-      resolve: "./modules/hello",
-    }
-  ]
-})
+```bash
+npx medusa plugin:db:genreate
 ```
 
 ## Use Module
 
-You can resolve the main service of the module in other resources, such as an API route:
+You can use the module in customizations within the plugin or within the Medusa application using this module. When the plugin is added to a Medusa application, all its modules are registered as well.
+
+For example, to use the module in an API route:
 
 ```ts
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
-import HelloModuleService from "../../../modules/hello/service"
-import { HELLO_MODULE } from "../../../modules/hello"
+import BlogModuleService from "../../../modules/blog/service"
+import { BLOG_MODULE } from "../../../modules/blog"
 
 export async function GET(
   req: MedusaRequest,
   res: MedusaResponse
 ): Promise<void> {
-  const helloModuleService: HelloModuleService = req.scope.resolve(
-    HELLO_MODULE
+  const blogModuleService: BlogModuleService = req.scope.resolve(
+    BLOG_MODULE
   )
 
+  const posts = await blogModuleService.listPosts()
+
   res.json({
-    message: helloModuleService.getMessage(),
+    posts
   })
 }
 ```
+


### PR DESCRIPTION
Update keywords in `package.json` to fit better plugins (removing outdated keywords too). Also, I've added the `medusa-plugin-other` which was one of the keywords in v1 that allowed us to scrape plugins. Not sure whether we'll use the same method for v2 but just in case.